### PR TITLE
[feature] getting rid of default encoding - changing it to utf-8

### DIFF
--- a/docs/generate-auto-docs.py
+++ b/docs/generate-auto-docs.py
@@ -53,7 +53,7 @@ for plugin_rules in get_plugin_manager().hook.get_rules():
 # Write them into a json file for use by redirects.
 print("Rule Docs Generation: Writing Rule JSON...")
 with open(base_path / "source/_partials/rule_list.json", "w", encoding="utf8") as f:
-    json.dump(rule_list, f)
+    json.dump(rule_list, f, ensure_ascii=False)
 
 # Write them into the table. Bundle by bundle.
 print("Rule Docs Generation: Writing Rule Table...")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -112,7 +112,7 @@ html_theme_options = {
 # https://documatt.gitlab.io/sphinx-reredirects/usage.html
 
 # Load the rule lists to generate rule permalinks
-with open("_partials/rule_list.json", "r") as rule_file:
+with open("_partials/rule_list.json", "r", encoding="utf8") as rule_file:
     rule_list = json.load(rule_file)
 
 redirects = {

--- a/plugins/sqlfluff-templater-dbt/test/linter_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/linter_test.py
@@ -70,7 +70,7 @@ def test_dbt_target_dir(tmpdir, dbt_project_folder, profiles_dir):
     # "target" directory would incorrectly be created in <<tmp_project_dir>>.
     # (It should be created in <<tmp_project_dir>>/dir1/dir2/dbt/dbt_project.)
     os.chdir(tmp_base_dir)
-    with open(".sqlfluff", "w") as f:
+    with open(".sqlfluff", "w", encoding="utf8") as f:
         print(
             f"""[sqlfluff]
 templater = dbt

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -408,9 +408,12 @@ def test__dbt_templated_models_fix_does_not_corrupt_file(
         lnt = lntr.lint_path(os.path.join(project_dir, path), fix=True)
     try:
         lnt.persist_changes(fixed_file_suffix="FIXED")
-        with open(os.path.join(project_dir, path + ".after")) as f:
+        with open(os.path.join(project_dir, path + ".after"), encoding="utf8") as f:
             comp_buff = f.read()
-        with open(os.path.join(project_dir, path.replace(".sql", "FIXED.sql"))) as f:
+        with open(
+            os.path.join(project_dir, path.replace(".sql", "FIXED.sql")),
+            encoding="utf8",
+        ) as f:
             fixed_buff = f.read()
         assert fixed_buff == comp_buff
     finally:

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -526,7 +526,7 @@ def dump_file_payload(filename: Optional[str], payload: str) -> None:
     """Write the output file content to stdout or file."""
     # If there's a file specified to write to, write to it.
     if filename:
-        with open(filename, "w") as out_file:
+        with open(filename, "w", encoding="utf8") as out_file:
             out_file.write(payload)
     # Otherwise write to stdout
     else:
@@ -660,7 +660,7 @@ def lint(
         click.echo(formatter.format_linting_stats(result, verbose=verbose))
 
     if format == FormatType.json.value:
-        file_output = json.dumps(result.as_records())
+        file_output = json.dumps(result.as_records(), ensure_ascii=False)
     elif format == FormatType.yaml.value:
         file_output = yaml.dump(
             result.as_records(),
@@ -707,7 +707,7 @@ def lint(
                         ),
                     }
                 )
-        file_output = json.dumps(github_result)
+        file_output = json.dumps(github_result, ensure_ascii=False)
     elif format == FormatType.github_annotation_native.value:
         if annotation_level == "failure":
             annotation_level = "error"
@@ -1404,7 +1404,7 @@ def parse(
                 allow_unicode=True,
             )
         elif format == FormatType.json.value:
-            file_output = json.dumps(parsed_strings_dict)
+            file_output = json.dumps(parsed_strings_dict, ensure_ascii=False)
         elif format == FormatType.none.value:
             file_output = ""
 

--- a/src/sqlfluff/cli/outputstream.py
+++ b/src/sqlfluff/cli/outputstream.py
@@ -48,7 +48,7 @@ class FileOutput(OutputStream):
 
     def __init__(self, config: FluffConfig, output_path: str) -> None:
         super().__init__(config)
-        self.file = open(output_path, "w")
+        self.file = open(output_path, "w", encoding="utf8")
 
     def write(self, message: str) -> None:
         """Write message to output_path."""

--- a/src/sqlfluff/core/config/file.py
+++ b/src/sqlfluff/core/config/file.py
@@ -47,7 +47,7 @@ def _load_raw_file_as_dict(filepath: str) -> ConfigMappingType:
     if filename == "pyproject.toml":
         return load_toml_file_config(filepath)
     # If it's not a pyproject file, assume that it's an ini file.
-    with open(filepath, mode="r") as file:
+    with open(filepath, mode="r", encoding="utf8") as file:
         return load_ini_string(file.read())
 
 

--- a/src/sqlfluff/core/config/toml.py
+++ b/src/sqlfluff/core/config/toml.py
@@ -54,7 +54,7 @@ def load_toml_file_config(filepath: str) -> ConfigMappingType:
     We don't need to change any key names here, because the root
     section of the toml file format is `tool.sqlfluff.core`.
     """
-    with open(filepath, mode="r") as file:
+    with open(filepath, mode="r", encoding="utf8") as file:
         toml_dict = tomllib.loads(file.read())
     config_dict = _validate_structure(toml_dict.get("tool", {}).get("sqlfluff", {}))
 

--- a/src/sqlfluff/core/linter/discovery.py
+++ b/src/sqlfluff/core/linter/discovery.py
@@ -70,7 +70,7 @@ def _load_specs_from_lines(
 def _load_ignorefile(dirpath: str, filename: str) -> IgnoreSpecRecord:
     """Load a sqlfluffignore file, returning the parsed spec."""
     filepath = os.path.join(dirpath, filename)
-    with open(filepath, mode="r") as f:
+    with open(filepath, mode="r", encoding="utf8") as f:
         spec = _load_specs_from_lines(f, filepath)
     return dirpath, filename, spec
 

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -157,7 +157,7 @@ class LintingResult:
 
         rule_codes -= set(timing_fields)
 
-        with open(filename, "w", newline="") as f:
+        with open(filename, "w", newline="", encoding="utf8") as f:
             writer = csv.DictWriter(
                 # Metadata first, then step timings and then _sorted_ rule codes.
                 f,

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -161,7 +161,7 @@ class JinjaTemplater(PythonTemplater):
                     ):
                         continue
                 # It's a file. Extract macros from it.
-                with open(path_entry) as opened_file:
+                with open(path_entry, encoding="utf8") as opened_file:
                     template = opened_file.read()
                 # Update the context with macros from the file.
                 try:

--- a/src/sqlfluff/utils/testing/rules.py
+++ b/src/sqlfluff/utils/testing/rules.py
@@ -35,7 +35,7 @@ def load_test_cases(
     test_cases = []
 
     for path in sorted(glob(test_cases_path)):
-        with open(path) as f:
+        with open(path, encoding="utf8") as f:
             raw = f.read()
 
         y = yaml.safe_load(raw)

--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -477,7 +477,11 @@ def test__api__parse_string():
     assert isinstance(parsed, dict)
 
     # Load in expected result.
-    with open("test/fixtures/api/parse_test/parse_test.json", "r") as f:
+    with open(
+        "test/fixtures/api/parse_test/parse_test.json",
+        mode="r",
+        encoding="utf8",
+    ) as f:
         expected_parsed = json.load(f)
 
     # Compare JSON from parse to expected result.
@@ -506,7 +510,11 @@ Line 1, Position 41: Found unparsable section: 'blah'"""
 def test__api__config_path():
     """Test that we can load a specified config file in the Simple API."""
     # Load test SQL file.
-    with open("test/fixtures/api/config_path_test/config_path_test.sql", "r") as f:
+    with open(
+        "test/fixtures/api/config_path_test/config_path_test.sql",
+        mode="r",
+        encoding="utf8",
+    ) as f:
         sql = f.read()
 
     # Pass a config path to the Simple API.
@@ -516,7 +524,11 @@ def test__api__config_path():
     )
 
     # Load in expected result.
-    with open("test/fixtures/api/config_path_test/config_path_test.json", "r") as f:
+    with open(
+        "test/fixtures/api/config_path_test/config_path_test.json",
+        mode="r",
+        encoding="utf8",
+    ) as f:
         expected_parsed = json.load(f)
 
     # Compare JSON from parse to expected result.
@@ -551,7 +563,11 @@ def test__api__config_override(kwargs, expected, tmpdir):
 def test__api__invalid_dialect():
     """Test that SQLFluffUserError is raised for a bad dialect."""
     # Load test SQL file.
-    with open("test/fixtures/api/config_path_test/config_path_test.sql", "r") as f:
+    with open(
+        "test/fixtures/api/config_path_test/config_path_test.sql",
+        mode="r",
+        encoding="utf8",
+    ) as f:
         sql = f.read()
 
     # Pass a fake dialect to the API and test the correct error is raised.

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -359,7 +359,7 @@ def test__cli__command_lint_stdin(command):
 
     The subprocess command should exit without errors, as no issues should be found.
     """
-    with open("test/fixtures/cli/passing_a.sql") as test_file:
+    with open("test/fixtures/cli/passing_a.sql", encoding="utf8") as test_file:
         sql = test_file.read()
     invoke_assert_code(args=[lint, ("--dialect=ansi",) + command], cli_input=sql)
 
@@ -374,7 +374,7 @@ def test__cli__command_lint_empty_stdin():
 
 def test__cli__command_render_stdin():
     """Check render on a simple script using stdin."""
-    with open("test/fixtures/cli/passing_a.sql") as test_file:
+    with open("test/fixtures/cli/passing_a.sql", encoding="utf8") as test_file:
         sql = test_file.read()
 
     invoke_assert_code(
@@ -835,7 +835,7 @@ def test__cli__command_versioning():
     # Get the package version info
     pkg_version = sqlfluff.__version__
     # Get the version info from the config file
-    with open("pyproject.toml", "r") as config_file:
+    with open("pyproject.toml", "r", encoding="utf8") as config_file:
         config = tomllib.loads(config_file.read())
     config_version = config["project"]["version"]
     assert pkg_version == config_version
@@ -941,7 +941,7 @@ def generic_roundtrip_test(
 )
 def test__cli__command__fix(rule, fname):
     """Test the round trip of detecting, fixing and then not detecting the rule."""
-    with open(fname) as test_file:
+    with open(fname, encoding="utf8") as test_file:
         generic_roundtrip_test(test_file, rule)
 
 
@@ -1119,7 +1119,7 @@ def test_cli_fix_even_unparsable(
     """Test the fix_even_unparsable option works from cmd line and config."""
     sql_filename = "fix_even_unparsable.sql"
     sql_path = str(tmpdir / sql_filename)
-    with open(sql_path, "w") as f:
+    with open(sql_path, "w", encoding="utf8") as f:
         print(
             """SELECT my_col
 FROM my_schema.my_table
@@ -1138,7 +1138,7 @@ where processdate ! 3
             options.append("--FIX-EVEN-UNPARSABLE")
     else:
         assert method == "config-file"
-        with open(str(tmpdir / ".sqlfluff"), "w") as f:
+        with open(str(tmpdir / ".sqlfluff"), "w", encoding="utf8") as f:
             print(
                 f"[sqlfluff]\nfix_even_unparsable = {fix_even_unparsable}",
                 file=f,
@@ -1157,7 +1157,7 @@ where processdate ! 3
     )
     fixed_path = str(tmpdir / "fix_even_unparsableFIXED.sql")
     if fix_even_unparsable:
-        with open(fixed_path, "r") as f:
+        with open(fixed_path, "r", encoding="utf8") as f:
             fixed_sql = f.read()
             assert (
                 fixed_sql
@@ -1307,7 +1307,7 @@ def test__cli__command_fix_stdin_error_exit_code(
 )
 def test__cli__command__fix_check(rule, fname, prompt, exit_code, fix_exit_code):
     """Round trip test, using the prompts."""
-    with open(fname) as test_file:
+    with open(fname, encoding="utf8") as test_file:
         generic_roundtrip_test(
             test_file,
             rule,
@@ -1339,7 +1339,7 @@ def test__cli__command_parse_serialize_from_stdin(serialize, write_file, tmp_pat
     )
 
     if write_file:
-        with open(target_file, "r") as payload_file:
+        with open(target_file, "r", encoding="utf8") as payload_file:
             result_payload = payload_file.read()
     else:
         result_payload = result.output
@@ -1579,7 +1579,7 @@ def test__cli__command_lint_nocolor(isatty, should_strip_ansi, capsys, tmpdir):
         lint(cmd_args)
     out = capsys.readouterr()[0]
     assert not contains_ansi_escape(out)
-    with open(output_file, "r") as f:
+    with open(output_file, "r", encoding="utf8") as f:
         file_contents = f.read()
     assert not contains_ansi_escape(file_contents)
 
@@ -1621,7 +1621,7 @@ def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_
 
     # NOTE: The "none" serializer doesn't write a file even if specified.
     if write_file and serialize != "none":
-        with open(target_file, "r") as payload_file:
+        with open(target_file, "r", encoding="utf8") as payload_file:
             result_payload = payload_file.read()
     else:
         result_payload = result.output
@@ -1904,7 +1904,11 @@ def test___main___help():
 )
 def test_encoding(encoding_in, encoding_out):
     """Check the encoding of the test file remains the same after fix is applied."""
-    with open("test/fixtures/linter/indentation_errors.sql", "r") as testfile:
+    with open(
+        "test/fixtures/linter/indentation_errors.sql",
+        mode="r",
+        encoding="utf8",
+    ) as testfile:
         generic_roundtrip_test(
             testfile,
             "LT01",
@@ -1929,7 +1933,7 @@ def test_cli_encoding(encoding, method, expect_success, tmpdir):
         options = [sql_path, "--encoding", encoding]
     else:
         assert method == "config-file"
-        with open(str(tmpdir / ".sqlfluff"), "w") as f:
+        with open(str(tmpdir / ".sqlfluff"), "w", encoding="utf8") as f:
             print(f"[sqlfluff]\ndialect=ansi\nencoding = {encoding}", file=f)
         shutil.copy(sql_path, tmpdir)
         options = [str(tmpdir / "encoding_test.sql")]

--- a/test/cli/formatters_test.py
+++ b/test/cli/formatters_test.py
@@ -114,7 +114,7 @@ def test__cli__fix_no_corrupt_file_contents(sql, fix_args, expected, tmpdir):
     with tmpdir.as_cwd():
         with pytest.raises(SystemExit):
             fix(fix_args)
-    with open(tmp_path / "testing.sql", "r") as fin:
+    with open(tmp_path / "testing.sql", "r", encoding="utf8") as fin:
         actual = fin.read()
 
     # Ensure no corruption in formatted file

--- a/test/core/config/fluffconfig_test.py
+++ b/test/core/config/fluffconfig_test.py
@@ -207,7 +207,8 @@ def test__config__from_kwargs():
 def test__config__from_string():
     """Test from_string method of FluffConfig."""
     with open(
-        os.path.join("test", "fixtures", "config", "inheritance_a", ".sqlfluff")
+        os.path.join("test", "fixtures", "config", "inheritance_a", ".sqlfluff"),
+        encoding="utf8",
     ) as f:
         config_string = f.read()
     cfg = FluffConfig.from_string(config_string)

--- a/test/core/config/loader_test.py
+++ b/test/core/config/loader_test.py
@@ -44,7 +44,8 @@ def test__config__load_from_string():
     """Test loading config from a string."""
     # Load a string
     with open(
-        os.path.join("test", "fixtures", "config", "inheritance_a", ".sqlfluff")
+        os.path.join("test", "fixtures", "config", "inheritance_a", ".sqlfluff"),
+        encoding="utf8",
     ) as f:
         config_string = f.read()
     cfg = load_config_string(config_string)

--- a/test/core/linter/linter_test.py
+++ b/test/core/linter/linter_test.py
@@ -87,7 +87,7 @@ def test__linter__skip_large_bytes(filesize, raises_skip):
 )
 def test__linter__lint_string_vs_file(path):
     """Test the linter finds the same things on strings and files."""
-    with open(path) as f:
+    with open(path, encoding="utf8") as f:
         sql_str = f.read()
     lntr = Linter(dialect="ansi")
     assert (

--- a/test/dialects/ansi_test.py
+++ b/test/dialects/ansi_test.py
@@ -182,7 +182,10 @@ def test__dialect__ansi_specific_segment_not_parse(raw, err_locations):
 def test__dialect__ansi_is_whitespace():
     """Test proper tagging with is_whitespace."""
     lnt = Linter(dialect="ansi")
-    with open("test/fixtures/dialects/ansi/select_in_multiline_comment.sql") as f:
+    with open(
+        "test/fixtures/dialects/ansi/select_in_multiline_comment.sql",
+        encoding="utf8",
+    ) as f:
         parsed = lnt.parse_string(f.read())
     # Check all the segments that *should* be whitespace, ARE
     for raw_seg in parsed.tree.get_raw_segments():

--- a/test/rules/std_fix_auto_test.py
+++ b/test/rules/std_fix_auto_test.py
@@ -74,7 +74,7 @@ def auto_fix_test(dialect, folder, caplog):
     )
 
     # Load the config file for the test:
-    with open(test_conf_filepath) as cfg_file:
+    with open(test_conf_filepath, encoding="utf8") as cfg_file:
         cfg = yaml.safe_load(cfg_file)
     print("## Config: ", cfg)
     rules: Optional[str] = ",".join(cfg["test-config"].get("rules")).upper()
@@ -86,15 +86,15 @@ def auto_fix_test(dialect, folder, caplog):
 
     # Open the example file and write the content to it
     print_buff = ""
-    with open(filepath, mode="w") as dest_file:
-        with open(src_filepath) as source_file:
+    with open(filepath, mode="w", encoding="utf8") as dest_file:
+        with open(src_filepath, encoding="utf8") as source_file:
             for line in source_file:
                 dest_file.write(line)
                 print_buff += line
     # Copy the config file too
     try:
-        with open(cfgpath, mode="w") as dest_file:
-            with open(cfg_filepath) as source_file:
+        with open(cfgpath, mode="w", encoding="utf8") as dest_file:
+            with open(cfg_filepath, encoding="utf8") as source_file:
                 print("## Config File Found.")
                 for line in source_file:
                     dest_file.write(line)
@@ -105,7 +105,7 @@ def auto_fix_test(dialect, folder, caplog):
     print(f"## Input file:\n{print_buff}")
     # Do we need to do a violations check?
     try:
-        with open(vio_filepath) as vio_file:
+        with open(vio_filepath, encoding="utf8") as vio_file:
             violations = json.load(vio_file)
     except FileNotFoundError:
         # No violations file. Let's not worry
@@ -147,14 +147,14 @@ def auto_fix_test(dialect, folder, caplog):
     # Actually do the fixes
     res = res.persist_changes()
     # Read the fixed file
-    with open(filepath) as fixed_file:
+    with open(filepath, encoding="utf8") as fixed_file:
         fixed_buff = fixed_file.read()
     # Clear up once read
     shutil.rmtree(tempdir_path)
     # Also clear the config cache again so it's not polluted for later tests.
     clear_config_caches()
     # Read the comparison file
-    with open(cmp_filepath) as comp_file:
+    with open(cmp_filepath, encoding="utf8") as comp_file:
         comp_buff = comp_file.read()
 
     # Make sure we were successful

--- a/test/rules/std_roundtrip_test.py
+++ b/test/rules/std_roundtrip_test.py
@@ -20,7 +20,7 @@ def generic_roundtrip_test(source_file, rulestring):
     """
     if isinstance(source_file, str):
         # If it's a string, treat it as a path so lets load it.
-        with open(source_file) as f:
+        with open(source_file, encoding="utf8") as f:
             source_file = StringIO(f.read())
 
     filename = "testing.sql"
@@ -28,7 +28,7 @@ def generic_roundtrip_test(source_file, rulestring):
     tempdir_path = tempfile.mkdtemp()
     filepath = os.path.join(tempdir_path, filename)
     # Open the example file and write the content to it
-    with open(filepath, mode="w") as dest_file:
+    with open(filepath, mode="w", encoding="utf8") as dest_file:
         for line in source_file:
             dest_file.write(line)
     runner = CliRunner()
@@ -61,17 +61,17 @@ def jinja_roundtrip_test(
     cfg_filepath = os.path.join(tempdir_path, cfgfile)
 
     # Copy the SQL file
-    with open(sql_filepath, mode="w") as dest_file:
-        with open(os.path.join(source_path, sqlfile)) as source_file:
+    with open(sql_filepath, mode="w", encoding="utf8") as dest_file:
+        with open(os.path.join(source_path, sqlfile), encoding="utf8") as source_file:
             for line in source_file:
                 dest_file.write(line)
     # Copy the Config file
-    with open(cfg_filepath, mode="w") as dest_file:
-        with open(os.path.join(source_path, cfgfile)) as source_file:
+    with open(cfg_filepath, mode="w", encoding="utf8") as dest_file:
+        with open(os.path.join(source_path, cfgfile), encoding="utf8") as source_file:
             for line in source_file:
                 dest_file.write(line)
 
-    with open(sql_filepath) as f:
+    with open(sql_filepath, encoding="utf8") as f:
         # Get a record of the pre-existing jinja tags
         tags = re.findall(r"{{[^}]*}}|{%[^}%]*%}", f.read(), flags=0)
 
@@ -93,13 +93,13 @@ def jinja_roundtrip_test(
     if result.exit_code != 0:
         # Output the file content for debugging
         print("File content:")
-        with open(sql_filepath) as f:
+        with open(sql_filepath, encoding="utf8") as f:
             print(repr(f.read()))
         print("Command output:")
         print(result.output)
     assert result.exit_code == 0
 
-    with open(sql_filepath) as f:
+    with open(sql_filepath, encoding="utf8") as f:
         # Check that the tags are all still there!
         new_tags = re.findall(r"{{[^}]*}}|{%[^}%]*%}", f.read(), flags=0)
 

--- a/util.py
+++ b/util.py
@@ -204,9 +204,9 @@ def release(new_version_num):
 
     click.echo("Updating plugins/sqlfluff-templater-dbt/pyproject.toml")
     for filename in ["plugins/sqlfluff-templater-dbt/pyproject.toml"]:
-        input_file = open(filename, "r").readlines()
+        input_file = open(filename, "r", encoding="utf8").readlines()
         # Regardless of platform, write newlines as \n
-        write_file = open(filename, "w", newline="\n")
+        write_file = open(filename, "w", newline="\n", encoding="utf8")
         for line in input_file:
             if line.startswith("version"):
                 line = f'version = "{new_version_num}"\n'
@@ -222,9 +222,9 @@ def release(new_version_num):
 
     click.echo("Updating pyproject.toml")
     for filename in ["pyproject.toml"]:
-        input_file = open(filename, "r").readlines()
+        input_file = open(filename, "r", encoding="utf8").readlines()
         # Regardless of platform, write newlines as \n
-        write_file = open(filename, "w", newline="\n")
+        write_file = open(filename, "w", newline="\n", encoding="utf8")
         for line in input_file:
             for key in keys:
                 if line.startswith(key):
@@ -237,9 +237,9 @@ def release(new_version_num):
     if not is_pre_release:
         click.echo("Updating gettingstarted.rst")
         for filename in ["docs/source/gettingstarted.rst"]:
-            input_file = open(filename, "r").readlines()
+            input_file = open(filename, "r", encoding="utf8").readlines()
             # Regardless of platform, write newlines as \n
-            write_file = open(filename, "w", newline="\n")
+            write_file = open(filename, "w", newline="\n", encoding="utf8")
             change_next_line = False
             for line in input_file:
                 if change_next_line:


### PR DESCRIPTION
### Brief summary of the change made

Getting rid of default (global) encoding for systems like Windows (cp1251, cp66, etc.).
Inspired by "Fluent Python" (Book by Luciano Ramalho)

### Manually checked on environments (constraints/)
- Env: Ubuntu 22.04.4 LTS; Python 3.10.12:
  - dbt140.txt
  - dbt150.txt
  - dbt160.txt
  - dbt170.txt
  - dbt180.txt

- Env: Windows 10 10.0.19044; Python 3.10.10:
  - dbt150-winpy.txt
  - dbt180-winpy.txt


### Are there any other side effects of this change that we should be aware of?
This changes affect core, so we need to be careful with review.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
